### PR TITLE
Add Markdown output format

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    couve (0.4.0)
+    couve (0.5.0)
 
 GEM
   remote: https://rubygems.org/
@@ -33,10 +33,10 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     lumberjack (1.2.9)
     method_source (1.0.0)
+    mini_portile2 (2.8.9)
     nenv (0.3.0)
-    nokogiri (1.15.3-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.15.3-x86_64-linux)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -88,6 +88,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-23
   x86_64-darwin-21
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@ $ couve path/to/coverage.json path/to/report.html   # HTML report
 $ couve path/to/coverage.json path/to/report.md      # Markdown report
 ```
 
-The Markdown report renders as a GitHub-flavored table, with a colored indicator (🔴/🟡/🟢) reflecting each file's coverage level:
+The Markdown report renders as a GitHub-flavored table, with a colored rating indicator (🔴/🟡/🟢) reflecting each file's coverage level:
 
 ```markdown
 ## Coverage problems
 
-| Coverage | File | Not covered lines |
-| --- | --- | --- |
-| 🔴 30% | app/models/foo.rb | 3, 8, 21 |
-| 🟡 50% | app/services/bar.rb | 5, 6 |
+| Rating | Coverage | File | Not covered lines |
+| :---: | ---: | :--- | :--- |
+| 🔴 | 30% | app/models/foo.rb | 3, 8, 21 |
+| 🟡 | 50% | app/services/bar.rb | 5, 6 |
 ```
 
 A typical CI setup keeps the HTML report as an artifact and posts the Markdown report to the pull request, e.g. with the GitHub CLI:

--- a/README.md
+++ b/README.md
@@ -26,13 +26,44 @@ Or install it yourself as:
 gem install couve
 ```
 
-2. Run the following command in your terminal, providing the path to your JSON coverage file and the desired output HTML file.
+2. Run the following command in your terminal, providing the path to your JSON coverage file and the desired output file.
 
 ```
 $ couve path/to/coverage.json path/to/output.html
 ```
 
 Couve will process the coverage data and generate a human-readable HTML report, providing insights into your project's test coverage.
+
+### Output formats
+
+Couve picks the output format from the output file's extension:
+
+- `.html` (or anything else) — a self-contained, styled **HTML** report. Great for uploading as a CI artifact.
+- `.md` — a **Markdown** report. Great for posting as a pull request comment.
+
+```
+$ couve path/to/coverage.json path/to/report.html   # HTML report
+$ couve path/to/coverage.json path/to/report.md      # Markdown report
+```
+
+The Markdown report renders as a GitHub-flavored table, with a colored indicator (🔴/🟡/🟢) reflecting each file's coverage level:
+
+```markdown
+## Coverage problems
+
+| Coverage | File | Not covered lines |
+| --- | --- | --- |
+| 🔴 30% | app/models/foo.rb | 3, 8, 21 |
+| 🟡 50% | app/services/bar.rb | 5, 6 |
+```
+
+A typical CI setup keeps the HTML report as an artifact and posts the Markdown report to the pull request, e.g. with the GitHub CLI:
+
+```sh
+couve coverage.json coverage.html   # upload as a CI artifact
+couve coverage.json coverage.md     # post to the PR
+gh pr comment "$PR_NUMBER" --body-file coverage.md
+```
 
 ## Development
 

--- a/lib/couve.rb
+++ b/lib/couve.rb
@@ -11,8 +11,10 @@ module Couve
     coverage = File.read(coverage_file)
     parser = Couve::Parser.new(coverage)
 
+    report = output_file.end_with?(".md") ? parser.to_markdown : parser.to_html
+
     File.open(output_file, "w") do |f|
-      f.puts parser.to_html
+      f.puts report
     end
   end
 end

--- a/lib/couve/parser.rb
+++ b/lib/couve/parser.rb
@@ -43,14 +43,14 @@ module Couve
         percentage = source_file[:covered_percent].round(2)
         indicator = percentage_indicator(percentage)
 
-        "| #{indicator} #{percentage}% | #{source_file[:name]} | #{not_covered_lines(source_file)} |"
+        "| #{indicator} | #{percentage}% | #{source_file[:name]} | #{not_covered_lines(source_file)} |"
       end
 
       <<~MARKDOWN
         ## Coverage problems
 
-        | Coverage | File | Not covered lines |
-        | --- | --- | --- |
+        | Rating | Coverage | File | Not covered lines |
+        | :---: | ---: | :--- | :--- |
         #{rows.join("\n")}
       MARKDOWN
     end

--- a/lib/couve/parser.rb
+++ b/lib/couve/parser.rb
@@ -38,6 +38,23 @@ module Couve
       HTML
     end
 
+    def to_markdown
+      rows = @coverage[:source_files].map do |source_file|
+        percentage = source_file[:covered_percent].round(2)
+        indicator = percentage_indicator(percentage)
+
+        "| #{indicator} #{percentage}% | #{source_file[:name]} | #{not_covered_lines(source_file)} |"
+      end
+
+      <<~MARKDOWN
+        ## Coverage problems
+
+        | Coverage | File | Not covered lines |
+        | --- | --- | --- |
+        #{rows.join("\n")}
+      MARKDOWN
+    end
+
     private
 
     # rubocop:disable Metrics/MethodLength
@@ -81,6 +98,16 @@ module Couve
         "bg-warning"
       else
         "bg-success"
+      end
+    end
+
+    def percentage_indicator(percentage)
+      if percentage < 33.33
+        "🔴"
+      elsif percentage < 66.66
+        "🟡"
+      else
+        "🟢"
       end
     end
 

--- a/spec/lib/couve/parser_spec.rb
+++ b/spec/lib/couve/parser_spec.rb
@@ -347,11 +347,11 @@ RSpec.describe Couve::Parser do
       expected = <<~MARKDOWN
         ## Coverage problems
 
-        | Coverage | File | Not covered lines |
-        | --- | --- | --- |
-        | 🔴 30% | app/graphql/resolvers/people_resolver.rb | 22, 24, 33, 34, 36, 39, 43, 48, 49, 51 |
-        | 🟡 50% | app/javascript/routes.jsx | 24 |
-        | 🟢 93.33% | app/javascript/index.tsx | 28 |
+        | Rating | Coverage | File | Not covered lines |
+        | :---: | ---: | :--- | :--- |
+        | 🔴 | 30% | app/graphql/resolvers/people_resolver.rb | 22, 24, 33, 34, 36, 39, 43, 48, 49, 51 |
+        | 🟡 | 50% | app/javascript/routes.jsx | 24 |
+        | 🟢 | 93.33% | app/javascript/index.tsx | 28 |
       MARKDOWN
 
       subject = described_class.new(coverage)
@@ -428,8 +428,8 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage)
 
-        expect(subject.to_markdown).to include "| 🔴 0% | a |"
-        expect(subject.to_markdown).to include "| 🔴 33.32% | b |"
+        expect(subject.to_markdown).to include "| 🔴 | 0% | a |"
+        expect(subject.to_markdown).to include "| 🔴 | 33.32% | b |"
       end
 
       it "is yellow when coverage is between 33.34% and 66.65%" do
@@ -444,8 +444,8 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage)
 
-        expect(subject.to_markdown).to include "| 🟡 33.34% | a |"
-        expect(subject.to_markdown).to include "| 🟡 66.65% | b |"
+        expect(subject.to_markdown).to include "| 🟡 | 33.34% | a |"
+        expect(subject.to_markdown).to include "| 🟡 | 66.65% | b |"
       end
 
       it "is green when coverage is greater than 66.65%" do
@@ -460,8 +460,8 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage)
 
-        expect(subject.to_markdown).to include "| 🟢 66.66% | a |"
-        expect(subject.to_markdown).to include "| 🟢 99.99% | b |"
+        expect(subject.to_markdown).to include "| 🟢 | 66.66% | a |"
+        expect(subject.to_markdown).to include "| 🟢 | 99.99% | b |"
       end
     end
   end

--- a/spec/lib/couve/parser_spec.rb
+++ b/spec/lib/couve/parser_spec.rb
@@ -319,4 +319,150 @@ RSpec.describe Couve::Parser do
 
     expect(subject.to_html).to include expected.join("\n          ")
   end
+
+  describe "#to_markdown" do
+    it "returns a markdown report" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            {
+              "coverage": "[1,1,10,null,null,null,null,null,null,10,null,null,1,7,null,7,4,null,4,null,3,null,null,null,1,null,1,0,null,null,null,null,null,1,7,null,null,null,null,null,null,null]",
+              "covered_percent": 93.33333333333333,
+              "name": "app/javascript/index.tsx"
+            },
+            {
+              "coverage": "[null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,null,6,null,6,null,null,12,0,null,12,null,null,null,6]",
+              "covered_percent": 50,
+              "name": "app/javascript/routes.jsx"
+            },
+            {
+              "coverage": "[2,2,2,null,null,null,null,null,null,2,2,2,2,null,null,null,2,null,2,2,null,0,null,0,null,null,2,null,null,2,2,null,0,0,null,0,null,null,0,null,2,null,0,null,null,null,2,0,0,null,0,null,null]",
+              "covered_percent": 30,
+              "name": "app/graphql/resolvers/people_resolver.rb"
+            }
+          ]
+        }
+      COVERAGE
+
+      expected = <<~MARKDOWN
+        ## Coverage problems
+
+        | Coverage | File | Not covered lines |
+        | --- | --- | --- |
+        | 🔴 30% | app/graphql/resolvers/people_resolver.rb | 22, 24, 33, 34, 36, 39, 43, 48, 49, 51 |
+        | 🟡 50% | app/javascript/routes.jsx | 24 |
+        | 🟢 93.33% | app/javascript/index.tsx | 28 |
+      MARKDOWN
+
+      subject = described_class.new(coverage)
+
+      expect(subject.to_markdown).to eql expected
+    end
+
+    it "does not export files 100% covered" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            {
+              "coverage": "[1,1]",
+              "covered_percent": 100,
+              "name": "app/javascript/index.tsx"
+            },
+            {
+              "coverage": "[1,0]",
+              "covered_percent": 95,
+              "name": "app/javascript/routes.jsx"
+            }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage)
+
+      expect(subject.to_markdown).to include "95%"
+      expect(subject.to_markdown).to_not include "100%"
+      expect(subject.to_markdown).to_not include "index.tsx"
+    end
+
+    it "sorts by less covered first" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            {
+              "coverage": "[]",
+              "covered_percent": 93.33333333333333,
+              "name": "app/javascript/index.tsx"
+            },
+            {
+              "coverage": "[]",
+              "covered_percent": 83.33333333333334,
+              "name": "app/javascript/routes.jsx"
+            },
+            {
+              "coverage": "[]",
+              "covered_percent": 60,
+              "name": "app/graphql/resolvers/people_resolver.rb"
+            }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage)
+
+      rows = subject.to_markdown.lines.grep(/\| /).reject { |line| line.include?("---") || line.include?("Coverage |") }
+      found_percentages = rows.map { |row| row[/\d+(\.\d+)?%/] }
+
+      expect(found_percentages).to eql ["60%", "83.33%", "93.33%"]
+    end
+
+    describe "coverage level indicators" do
+      it "is red when coverage is less than 33.33%" do
+        coverage = <<~COVERAGE
+          {
+            "source_files": [
+              { "coverage": "[]", "covered_percent": 0, "name": "a" },
+              { "coverage": "[]", "covered_percent": 33.32, "name": "b" }
+            ]
+          }
+        COVERAGE
+
+        subject = described_class.new(coverage)
+
+        expect(subject.to_markdown).to include "| 🔴 0% | a |"
+        expect(subject.to_markdown).to include "| 🔴 33.32% | b |"
+      end
+
+      it "is yellow when coverage is between 33.34% and 66.65%" do
+        coverage = <<~COVERAGE
+          {
+            "source_files": [
+              { "coverage": "[]", "covered_percent": 33.34, "name": "a" },
+              { "coverage": "[]", "covered_percent": 66.65, "name": "b" }
+            ]
+          }
+        COVERAGE
+
+        subject = described_class.new(coverage)
+
+        expect(subject.to_markdown).to include "| 🟡 33.34% | a |"
+        expect(subject.to_markdown).to include "| 🟡 66.65% | b |"
+      end
+
+      it "is green when coverage is greater than 66.65%" do
+        coverage = <<~COVERAGE
+          {
+            "source_files": [
+              { "coverage": "[]", "covered_percent": 66.66, "name": "a" },
+              { "coverage": "[]", "covered_percent": 99.99, "name": "b" }
+            ]
+          }
+        COVERAGE
+
+        subject = described_class.new(coverage)
+
+        expect(subject.to_markdown).to include "| 🟢 66.66% | a |"
+        expect(subject.to_markdown).to include "| 🟢 99.99% | b |"
+      end
+    end
+  end
 end

--- a/spec/lib/couve_spec.rb
+++ b/spec/lib/couve_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Couve do
       generated = File.read(output_file)
 
       expect(generated).to start_with "## Coverage problems\n"
-      expect(generated).to include "| Coverage | File | Not covered lines |"
+      expect(generated).to include "| Rating | Coverage | File | Not covered lines |"
       expect(generated).to_not include "<html>"
     end
   end

--- a/spec/lib/couve_spec.rb
+++ b/spec/lib/couve_spec.rb
@@ -26,5 +26,25 @@ RSpec.describe Couve do
 
       expect(generated).to eql expected
     end
+
+    it "generates the markdown report when the output file ends with .md" do
+      output_file = "tmp/coverage.md"
+
+      FileUtils.rm_f(output_file)
+      expect(File.exist?(output_file)).to be false
+
+      expect(ARGV).to receive(:[]).with(0).and_return("spec/fixtures/codeclimate.json")
+      expect(ARGV).to receive(:[]).with(1).and_return(output_file)
+
+      subject.start
+
+      expect(File.exist?(output_file)).to be true
+
+      generated = File.read(output_file)
+
+      expect(generated).to start_with "## Coverage problems\n"
+      expect(generated).to include "| Coverage | File | Not covered lines |"
+      expect(generated).to_not include "<html>"
+    end
   end
 end


### PR DESCRIPTION
Closes #7

## Summary

Adds Markdown as an alternative output format while keeping HTML as-is.

- Format is inferred from the output file extension: `.md` renders Markdown, anything else renders HTML.
- HTML remains the default, so existing invocations (`couve coverage.json output.html`) are unchanged.
- `Couve::Parser#to_markdown` renders a GitHub-flavored table with a colored indicator (🔴/🟡/🟢) reflecting each file's coverage level, reusing the existing filtering, sorting, and not-covered-lines logic.
- No new runtime dependency — selection is a plain extension check.
- README documents both formats and a CI workflow (HTML as artifact, Markdown posted to the PR).

## How to test

- `bundle exec rspec` — 16 examples, 0 failures.
- `bundle exec rubocop` — no offenses.
- Markdown: `couve spec/fixtures/codeclimate.json /tmp/report.md` produces a GFM table.
- HTML (default unchanged): `couve spec/fixtures/codeclimate.json /tmp/report.html` produces the HTML report.

## Notes

- Built with explicit TDD (red → green for both the parser method and the CLI format selection).
- The issue left comment-size capping as an open decision; this PR leaves row count to the consumer rather than capping. Can be addressed in a follow-up if desired.
- `Gemfile.lock` was refreshed (added `arm64-darwin-23` platform, resolved `nokogiri 1.15.3`) so the suite runs locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)