### PR TITLE
Add --changed-files option to report only touched files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Add `--changed-files` to report the coverage status of a given list of files (e.g. a branch's changed files), including fully covered ones, instead of the project-wide below-100% view.
+- Rename the report heading from "Coverage problems" to "Coverage report".
+
 ## [0.6.0] - 2026-06-04
 
 - Add Markdown output format, selected from the output file extension (`.md`). HTML remains the default.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,22 @@ couve coverage.json coverage.md     # post to the PR
 gh pr comment "$PR_NUMBER" --body-file coverage.md
 ```
 
+### Reporting only the files you changed
+
+By default the report lists every file in the coverage data that is below 100%. With `--changed-files` you flip that around: instead of a project-wide view, you get the coverage status of exactly the files you touched on a branch — including the ones that are fully covered.
+
+Pass a file with one repo-relative path per line, or `-` to read the list from standard input:
+
+```sh
+git diff --name-only origin/main...HEAD > changed.txt
+couve coverage.json report.md --changed-files changed.txt
+
+# or pipe the list straight in:
+git diff --name-only origin/main...HEAD | couve coverage.json report.md --changed-files -
+```
+
+Only files that appear both in the list and in the coverage data are shown; the rest of the project is left out. Coverage is still reported per file (the whole file's percentage and missed lines), not just the lines in your diff.
+
 ## Development
 
 To contribute to Couve's development, follow these steps:

--- a/lib/couve.rb
+++ b/lib/couve.rb
@@ -1,20 +1,40 @@
 # frozen_string_literal: true
 
+require "optparse"
+
 require_relative "couve/version"
 require_relative "couve/parser"
 
 module Couve
-  def self.start
-    coverage_file = ARGV[0]
-    output_file = ARGV[1]
+  def self.start(argv = ARGV)
+    coverage_file, output_file, changed_files_source = parse_arguments(argv)
 
     coverage = File.read(coverage_file)
-    parser = Couve::Parser.new(coverage)
+    parser = Couve::Parser.new(coverage, changed_files: changed_files(changed_files_source))
 
     report = output_file.end_with?(".md") ? parser.to_markdown : parser.to_html
 
-    File.open(output_file, "w") do |f|
-      f.puts report
-    end
+    File.open(output_file, "w") { |f| f.puts report }
+  end
+
+  def self.parse_arguments(argv)
+    argv = argv.dup
+    changed_files_source = nil
+
+    OptionParser.new do |opts|
+      opts.on("--changed-files PATH", "Only report the files listed in PATH (use - for stdin)") do |path|
+        changed_files_source = path
+      end
+    end.parse!(argv)
+
+    [argv[0], argv[1], changed_files_source]
+  end
+
+  def self.changed_files(source)
+    return nil unless source
+
+    contents = source == "-" ? $stdin.read : File.read(source)
+
+    contents.lines.map { |line| line.strip.delete_prefix("./") }.reject(&:empty?)
   end
 end

--- a/lib/couve/parser.rb
+++ b/lib/couve/parser.rb
@@ -4,9 +4,15 @@ require "json"
 
 module Couve
   class Parser
-    def initialize(coverage)
+    def initialize(coverage, changed_files: nil)
       @coverage = JSON.parse(coverage, symbolize_names: true)
-      @coverage[:source_files].reject! { |file| file[:covered_percent] == 100 }
+
+      if changed_files
+        @coverage[:source_files].select! { |file| changed_files.include?(file[:name]) }
+      else
+        @coverage[:source_files].reject! { |file| file[:covered_percent] == 100 }
+      end
+
       @coverage[:source_files].sort_by! { |file| file[:covered_percent] }
     end
 
@@ -16,7 +22,7 @@ module Couve
           <body>
             <div class="container mt-5">
               <h1 class="display-5">
-                Coverage problems
+                Coverage report
               </h1>
 
               <table class="table table-hover mt-5">
@@ -47,7 +53,7 @@ module Couve
       end
 
       <<~MARKDOWN
-        ## Coverage problems
+        ## Coverage report
 
         | Rating | Coverage | File | Not covered lines |
         | :---: | ---: | :--- | :--- |

--- a/spec/fixtures/coverage.html
+++ b/spec/fixtures/coverage.html
@@ -2,7 +2,7 @@
   <body>
     <div class="container mt-5">
       <h1 class="display-5">
-        Coverage problems
+        Coverage report
       </h1>
 
       <table class="table table-hover mt-5">

--- a/spec/lib/couve/parser_spec.rb
+++ b/spec/lib/couve/parser_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Couve::Parser do
         <body>
           <div class="container mt-5">
             <h1 class="display-5">
-              Coverage problems
+              Coverage report
             </h1>
 
             <table class="table table-hover mt-5">
@@ -345,7 +345,7 @@ RSpec.describe Couve::Parser do
       COVERAGE
 
       expected = <<~MARKDOWN
-        ## Coverage problems
+        ## Coverage report
 
         | Rating | Coverage | File | Not covered lines |
         | :---: | ---: | :--- | :--- |
@@ -463,6 +463,64 @@ RSpec.describe Couve::Parser do
         expect(subject.to_markdown).to include "| 🟢 | 66.66% | a |"
         expect(subject.to_markdown).to include "| 🟢 | 99.99% | b |"
       end
+    end
+  end
+
+  describe "with changed_files" do
+    let(:coverage) do
+      <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[1,1]", "covered_percent": 100, "name": "app/models/fully_covered.rb" },
+            { "coverage": "[1,0]", "covered_percent": 50, "name": "app/models/touched.rb" },
+            { "coverage": "[1,1,1,1,0]", "covered_percent": 80, "name": "app/models/untouched.rb" }
+          ]
+        }
+      COVERAGE
+    end
+
+    it "shows only the files in the list" do
+      subject = described_class.new(coverage, changed_files: ["app/models/touched.rb"])
+
+      expect(subject.to_markdown).to include "app/models/touched.rb"
+      expect(subject.to_markdown).to_not include "app/models/untouched.rb"
+    end
+
+    it "includes a fully covered file when it is in the list" do
+      subject = described_class.new(coverage, changed_files: ["app/models/fully_covered.rb"])
+
+      expect(subject.to_markdown).to include "| 🟢 | 100% | app/models/fully_covered.rb |"
+    end
+
+    it "excludes a file below 100% that is not in the list" do
+      subject = described_class.new(coverage, changed_files: ["app/models/touched.rb"])
+
+      expect(subject.to_markdown).to_not include "app/models/untouched.rb"
+    end
+
+    it "ignores listed paths that have no coverage data" do
+      subject = described_class.new(coverage, changed_files: ["app/models/touched.rb", "config/routes.rb"])
+
+      expect(subject.to_markdown).to include "app/models/touched.rb"
+      expect(subject.to_markdown).to_not include "config/routes.rb"
+    end
+
+    it "renders the listed files in the html report" do
+      subject = described_class.new(coverage, changed_files: ["app/models/fully_covered.rb", "app/models/touched.rb"])
+
+      doc = Nokogiri::HTML(subject.to_html)
+      names = doc.css("tbody tr td:nth-child(3)").map { |td| td.text.strip }
+
+      expect(names).to eql ["app/models/touched.rb", "app/models/fully_covered.rb"]
+    end
+
+    it "sorts the listed files by less covered first" do
+      subject = described_class.new(coverage, changed_files: ["app/models/fully_covered.rb", "app/models/touched.rb"])
+
+      rows = subject.to_markdown.lines.grep(/\| /).reject { |line| line.include?("---") || line.include?("Coverage |") }
+      found_percentages = rows.map { |row| row[/\d+(\.\d+)?%/] }
+
+      expect(found_percentages).to eql ["50%", "100%"]
     end
   end
 end

--- a/spec/lib/couve_spec.rb
+++ b/spec/lib/couve_spec.rb
@@ -14,10 +14,7 @@ RSpec.describe Couve do
       FileUtils.rm_f(output_file)
       expect(File.exist?(output_file)).to be false
 
-      expect(ARGV).to receive(:[]).with(0).and_return("spec/fixtures/codeclimate.json")
-      expect(ARGV).to receive(:[]).with(1).and_return(output_file)
-
-      subject.start
+      subject.start(["spec/fixtures/codeclimate.json", output_file])
 
       expect(File.exist?(output_file)).to be true
 
@@ -33,18 +30,42 @@ RSpec.describe Couve do
       FileUtils.rm_f(output_file)
       expect(File.exist?(output_file)).to be false
 
-      expect(ARGV).to receive(:[]).with(0).and_return("spec/fixtures/codeclimate.json")
-      expect(ARGV).to receive(:[]).with(1).and_return(output_file)
-
-      subject.start
+      subject.start(["spec/fixtures/codeclimate.json", output_file])
 
       expect(File.exist?(output_file)).to be true
 
       generated = File.read(output_file)
 
-      expect(generated).to start_with "## Coverage problems\n"
+      expect(generated).to start_with "## Coverage report\n"
       expect(generated).to include "| Rating | Coverage | File | Not covered lines |"
       expect(generated).to_not include "<html>"
+    end
+
+    it "filters to the files passed via --changed-files" do
+      output_file = "tmp/changed.md"
+      list_file = "tmp/changed.txt"
+
+      FileUtils.rm_f(output_file)
+      File.write(list_file, "app/javascript/routes.jsx\n")
+
+      subject.start(["spec/fixtures/codeclimate.json", output_file, "--changed-files", list_file])
+
+      generated = File.read(output_file)
+      expect(generated).to include "app/javascript/routes.jsx"
+      expect(generated).to_not include "people_resolver.rb"
+    end
+
+    it "reads the changed files from stdin when --changed-files is -" do
+      output_file = "tmp/changed_stdin.md"
+
+      FileUtils.rm_f(output_file)
+      allow($stdin).to receive(:read).and_return("./app/javascript/routes.jsx\n")
+
+      subject.start(["spec/fixtures/codeclimate.json", output_file, "--changed-files", "-"])
+
+      generated = File.read(output_file)
+      expect(generated).to include "app/javascript/routes.jsx"
+      expect(generated).to_not include "people_resolver.rb"
     end
   end
 end


### PR DESCRIPTION
## Summary

- Add `--changed-files` to report the coverage status of a given list of files (for example, a branch's changed files) instead of the project-wide below-100% view.
- Listed files are shown even when fully covered, so a dev sees the status of everything they touched.
- The list is read from a file (one repo-relative path per line) or from stdin via `-`; a leading `./` is stripped so `git diff --name-only` output joins cleanly.
- Only files present in both the list and the coverage data are shown. Coverage is still reported per whole file (percentage + missed lines), not isolated to the diff's added lines.
- Rename the report heading from "Coverage problems" to "Coverage report" (accurate for both the default and the changed-files view).

## How to test

- `bundle exec rspec` — 24 examples, 0 failures.
- `bundle exec rubocop` — no offenses.
- File list: `printf 'app/javascript/routes.jsx\n' > changed.txt && bundle exec exe/couve spec/fixtures/codeclimate.json report.md --changed-files changed.txt` — only `routes.jsx` appears.
- Stdin: `git diff --name-only origin/main...HEAD | bundle exec exe/couve coverage.json report.md --changed-files -`.
- No flag: `bundle exec exe/couve spec/fixtures/codeclimate.json report.md` — unchanged behavior (all below-100% files).

## Notes

- The default (no-flag) report keeps its existing filter; the only intentional change to it is the heading text.
- File-level by design: a touched file shows its whole coverage, including pre-existing uncovered lines the dev did not write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)