### PR TITLE
Add --fail-on-low-coverage flag to exit non-zero on under-covered files

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ git diff --name-only origin/main...HEAD | couve coverage.json report.md --change
 
 Only files that appear both in the list and in the coverage data are shown; the rest of the project is left out. Coverage is still reported per file (the whole file's percentage and missed lines), not just the lines in your diff.
 
+### Failing the build on low coverage
+
+By default couve always exits `0` — it only generates the report. Pass `--fail-on-low-coverage` to make couve exit `1` when any **reported** file is below the green threshold, i.e. rated 🔴 or 🟡 (`< 66.66%`):
+
+```sh
+couve coverage.json report.md --fail-on-low-coverage
+```
+
+The report is written **before** couve exits, so the offending files stay visible in the report (and in any PR comment built from it). The offending files are also printed to standard error:
+
+```
+couve: coverage below 66.66% in app/models/foo.rb, app/services/bar.rb
+```
+
+The threshold is the same fixed band used for the rating indicators; there is nothing to configure. The flag respects `--changed-files` scope: when you only report the files you changed, only those files are evaluated, so a green (or empty) changed-file set passes the build even if untouched files elsewhere are poorly covered.
+
+```sh
+# Post the report to the PR, then redden the build if a changed file is under-covered:
+git diff --name-only origin/main...HEAD | couve coverage.json report.md --changed-files - --fail-on-low-coverage
+```
+
 ## Development
 
 To contribute to Couve's development, follow these steps:

--- a/lib/couve.rb
+++ b/lib/couve.rb
@@ -7,7 +7,7 @@ require_relative "couve/parser"
 
 module Couve
   def self.start(argv = ARGV)
-    coverage_file, output_file, changed_files_source = parse_arguments(argv)
+    coverage_file, output_file, changed_files_source, fail_on_low_coverage = parse_arguments(argv)
 
     coverage = File.read(coverage_file)
     parser = Couve::Parser.new(coverage, changed_files: changed_files(changed_files_source))
@@ -15,19 +15,30 @@ module Couve
     report = output_file.end_with?(".md") ? parser.to_markdown : parser.to_html
 
     File.open(output_file, "w") { |f| f.puts report }
+
+    return unless fail_on_low_coverage && parser.low_coverage?
+
+    warn "couve: coverage below #{Couve::Parser::GREEN_THRESHOLD}% in #{parser.low_coverage_files.join(", ")}"
+    exit 1
   end
 
-  def self.parse_arguments(argv)
+  def self.parse_arguments(argv) # rubocop:disable Metrics/MethodLength
     argv = argv.dup
     changed_files_source = nil
+    fail_on_low_coverage = false
 
     OptionParser.new do |opts|
       opts.on("--changed-files PATH", "Only report the files listed in PATH (use - for stdin)") do |path|
         changed_files_source = path
       end
+
+      opts.on("--fail-on-low-coverage",
+              "Exit 1 if any reported file is below #{Couve::Parser::GREEN_THRESHOLD}% coverage") do
+        fail_on_low_coverage = true
+      end
     end.parse!(argv)
 
-    [argv[0], argv[1], changed_files_source]
+    [argv[0], argv[1], changed_files_source, fail_on_low_coverage]
   end
 
   def self.changed_files(source)

--- a/lib/couve/parser.rb
+++ b/lib/couve/parser.rb
@@ -3,7 +3,10 @@
 require "json"
 
 module Couve
-  class Parser
+  class Parser # rubocop:disable Metrics/ClassLength
+    RED_THRESHOLD = 33.33
+    GREEN_THRESHOLD = 66.66
+
     def initialize(coverage, changed_files: nil)
       @coverage = JSON.parse(coverage, symbolize_names: true)
 
@@ -61,6 +64,16 @@ module Couve
       MARKDOWN
     end
 
+    def low_coverage_files
+      @coverage[:source_files]
+        .select { |source_file| source_file[:covered_percent].round(2) < GREEN_THRESHOLD }
+        .map { |source_file| source_file[:name] }
+    end
+
+    def low_coverage?
+      low_coverage_files.any?
+    end
+
     private
 
     # rubocop:disable Metrics/MethodLength
@@ -98,9 +111,9 @@ module Couve
     # rubocop:enable Metrics/MethodLength
 
     def percentage_bar_color(percentage)
-      if percentage < 33.33
+      if percentage < RED_THRESHOLD
         "bg-danger"
-      elsif percentage < 66.66
+      elsif percentage < GREEN_THRESHOLD
         "bg-warning"
       else
         "bg-success"
@@ -108,9 +121,9 @@ module Couve
     end
 
     def percentage_indicator(percentage)
-      if percentage < 33.33
+      if percentage < RED_THRESHOLD
         "🔴"
-      elsif percentage < 66.66
+      elsif percentage < GREEN_THRESHOLD
         "🟡"
       else
         "🟢"

--- a/spec/lib/couve/parser_spec.rb
+++ b/spec/lib/couve/parser_spec.rb
@@ -523,4 +523,92 @@ RSpec.describe Couve::Parser do
       expect(found_percentages).to eql ["50%", "100%"]
     end
   end
+
+  describe "#low_coverage_files" do
+    it "returns only the files below the green threshold" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[]", "covered_percent": 30, "name": "app/red.rb" },
+            { "coverage": "[]", "covered_percent": 50, "name": "app/yellow.rb" },
+            { "coverage": "[]", "covered_percent": 80, "name": "app/green.rb" }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage)
+
+      expect(subject.low_coverage_files).to eql ["app/red.rb", "app/yellow.rb"]
+    end
+
+    it "treats 66.66% as green and 66.65% as low, matching the report indicators" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[]", "covered_percent": 66.65, "name": "app/low.rb" },
+            { "coverage": "[]", "covered_percent": 66.66, "name": "app/ok.rb" }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage)
+
+      expect(subject.low_coverage_files).to eql ["app/low.rb"]
+    end
+
+    it "rounds to two decimals like the report, so 66.659% counts as green" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[]", "covered_percent": 66.659, "name": "app/rounds_up.rb" }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage)
+
+      expect(subject.low_coverage_files).to be_empty
+    end
+
+    it "is scoped to the changed files when given" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[]", "covered_percent": 30, "name": "app/untouched_red.rb" },
+            { "coverage": "[]", "covered_percent": 95, "name": "app/touched_green.rb" }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage, changed_files: ["app/touched_green.rb"])
+
+      expect(subject.low_coverage_files).to be_empty
+    end
+  end
+
+  describe "#low_coverage?" do
+    it "is true when a reported file is below the green threshold" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[]", "covered_percent": 50, "name": "app/yellow.rb" }
+          ]
+        }
+      COVERAGE
+
+      expect(described_class.new(coverage).low_coverage?).to be true
+    end
+
+    it "is false when every reported file is green" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
+            { "coverage": "[]", "covered_percent": 80, "name": "app/green.rb" }
+          ]
+        }
+      COVERAGE
+
+      expect(described_class.new(coverage).low_coverage?).to be false
+    end
+  end
 end

--- a/spec/lib/couve_spec.rb
+++ b/spec/lib/couve_spec.rb
@@ -67,5 +67,72 @@ RSpec.describe Couve do
       expect(generated).to include "app/javascript/routes.jsx"
       expect(generated).to_not include "people_resolver.rb"
     end
+
+    context "with --fail-on-low-coverage" do
+      it "exits non-zero when a reported file is below the green threshold" do
+        output_file = "tmp/fail.md"
+        FileUtils.rm_f(output_file)
+
+        expect do
+          suppress_stderr { subject.start(["spec/fixtures/codeclimate.json", output_file, "--fail-on-low-coverage"]) }
+        end.to raise_error(SystemExit) { |error| expect(error.status).to eql 1 }
+      end
+
+      it "writes the report before exiting, so the offending files stay visible" do
+        output_file = "tmp/fail.md"
+        FileUtils.rm_f(output_file)
+
+        begin
+          suppress_stderr { subject.start(["spec/fixtures/codeclimate.json", output_file, "--fail-on-low-coverage"]) }
+        rescue SystemExit
+          # expected
+        end
+
+        expect(File.exist?(output_file)).to be true
+        expect(File.read(output_file)).to include "app/graphql/resolvers/people_resolver.rb"
+      end
+
+      it "prints the offending files to stderr" do
+        output_file = "tmp/fail.md"
+        FileUtils.rm_f(output_file)
+
+        expect do
+          subject.start(["spec/fixtures/codeclimate.json", output_file, "--fail-on-low-coverage"])
+        rescue SystemExit
+          # expected
+        end.to output(/couve: coverage below 66.66% in .*people_resolver\.rb/).to_stderr
+      end
+
+      it "does not exit when every reported file is green" do
+        output_file = "tmp/pass.md"
+        list_file = "tmp/pass.txt"
+        FileUtils.rm_f(output_file)
+        File.write(list_file, "app/javascript/routes.jsx\n")
+
+        expect do
+          subject.start(["spec/fixtures/codeclimate.json", output_file, "--changed-files", list_file,
+                         "--fail-on-low-coverage"])
+        end.to_not raise_error
+
+        expect(File.exist?(output_file)).to be true
+      end
+    end
+
+    it "does not exit on low coverage without the flag" do
+      output_file = "tmp/no_flag.md"
+      FileUtils.rm_f(output_file)
+
+      expect do
+        subject.start(["spec/fixtures/codeclimate.json", output_file])
+      end.to_not raise_error
+    end
+  end
+
+  def suppress_stderr
+    original = $stderr
+    $stderr = File.open(File::NULL, "w")
+    yield
+  ensure
+    $stderr = original
   end
 end


### PR DESCRIPTION
Closes #11

## Summary

- Add a boolean `--fail-on-low-coverage` CLI flag. When set, couve writes the report and then exits `1` if any **reported** file is below the green threshold (rated 🔴 or 🟡, `< 66.66%`).
- The report is written **before** exiting, so the offending files stay visible in the report and in any PR comment built from it.
- The offending files are printed to stderr, e.g. `couve: coverage below 66.66% in app/foo.rb, app/bar.rb`.
- Extract the `33.33` / `66.66` magic numbers into `RED_THRESHOLD` / `GREEN_THRESHOLD` constants (shared by `percentage_bar_color` and `percentage_indicator`).
- Add public `Couve::Parser#low_coverage?` and `#low_coverage_files`. Since the constructor already narrows the source files to the reported set, these automatically respect `--changed-files` scope — a green or empty changed-file set passes the build.

## How to test

- `bundle exec rspec` — 35 examples, 0 failures.
- `bin/rubocop` — no offenses.
- Fail case: `couve spec/fixtures/codeclimate.json report.md --fail-on-low-coverage` exits `1` (the fixture's `people_resolver.rb` is at 60%) and prints the offending file to stderr, while still writing `report.md`.
- Pass case: scope to a green file and confirm exit `0`: `echo app/javascript/routes.jsx | couve spec/fixtures/codeclimate.json report.md --changed-files - --fail-on-low-coverage`.

## Notes

- Reuses the existing fixed threshold band; no new or configurable threshold.
- No version bump or CHANGELOG entry in this PR (intentionally deferred to the release).
- Follow-up (separate repo): wire the flag into facil123's `.semaphore/semaphore.yml` Coverage block so it posts the comment first, then fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)