### PR TITLE
Raise GREEN_THRESHOLD to 100 so only fully covered files rate green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [0.9.0] - 2026-06-09
 
 - **Breaking:** raise the green threshold to 100%, so 🟢 now means the file is fully covered and `--fail-on-low-coverage` exits `1` for any reported file below 100% (previously 66.66%).
-- Rate files and evaluate the coverage gate on the unrounded percentage, so a file at e.g. 99.996% no longer rounds up to 100% and slips past the gate (rounding is kept for display only).
+- Rate files and evaluate the coverage gate on the unrounded percentage, so a file at e.g. 99.996% no longer rounds up to 100% and slips past the gate.
+- Display percentages with two decimal places in all cases (e.g. `60.00%`), flooring instead of rounding, so a partially covered file never displays as `100.00%`.
 
 ## [0.8.0] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-09
+
+- **Breaking:** raise the green threshold to 100%, so 🟢 now means the file is fully covered and `--fail-on-low-coverage` exits `1` for any reported file below 100% (previously 66.66%).
+- Rate files and evaluate the coverage gate on the unrounded percentage, so a file at e.g. 99.996% no longer rounds up to 100% and slips past the gate (rounding is kept for display only).
+
 ## [0.8.0] - 2026-06-05
 
 - Add `--fail-on-low-coverage` flag to exit with a non-zero status when any reported file is below 100% coverage.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    couve (0.8.0)
+    couve (0.9.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ The Markdown report renders as a GitHub-flavored table, with a colored rating in
 
 | Rating | Coverage | File | Not covered lines |
 | :---: | ---: | :--- | :--- |
-| 🔴 | 30% | app/models/foo.rb | 3, 8, 21 |
-| 🟡 | 50% | app/services/bar.rb | 5, 6 |
+| 🔴 | 30.00% | app/models/foo.rb | 3, 8, 21 |
+| 🟡 | 50.00% | app/services/bar.rb | 5, 6 |
 ```
 
 A typical CI setup keeps the HTML report as an artifact and posts the Markdown report to the pull request, e.g. with the GitHub CLI:

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ couve path/to/coverage.json path/to/report.html   # HTML report
 $ couve path/to/coverage.json path/to/report.md      # Markdown report
 ```
 
-The Markdown report renders as a GitHub-flavored table, with a colored rating indicator (🔴/🟡/🟢) reflecting each file's coverage level:
+The Markdown report renders as a GitHub-flavored table, with a colored rating indicator reflecting each file's coverage level — 🔴 below 33.33%, 🟡 from there up to (but not including) 100%, and 🟢 only for fully covered files:
 
 ```markdown
 ## Coverage problems
@@ -83,7 +83,7 @@ Only files that appear both in the list and in the coverage data are shown; the 
 
 ### Failing the build on low coverage
 
-By default couve always exits `0` — it only generates the report. Pass `--fail-on-low-coverage` to make couve exit `1` when any **reported** file is below the green threshold, i.e. rated 🔴 or 🟡 (`< 66.66%`):
+By default couve always exits `0` — it only generates the report. Pass `--fail-on-low-coverage` to make couve exit `1` when any **reported** file is below 100% coverage, i.e. rated 🔴 or 🟡:
 
 ```sh
 couve coverage.json report.md --fail-on-low-coverage
@@ -92,10 +92,10 @@ couve coverage.json report.md --fail-on-low-coverage
 The report is written **before** couve exits, so the offending files stay visible in the report (and in any PR comment built from it). The offending files are also printed to standard error:
 
 ```
-couve: coverage below 66.66% in app/models/foo.rb, app/services/bar.rb
+couve: coverage below 100% in app/models/foo.rb, app/services/bar.rb
 ```
 
-The threshold is the same fixed band used for the rating indicators; there is nothing to configure. The flag respects `--changed-files` scope: when you only report the files you changed, only those files are evaluated, so a green (or empty) changed-file set passes the build even if untouched files elsewhere are poorly covered.
+The threshold is fixed at 100%; there is nothing to configure. Note that the default report only lists files below 100%, so project-wide the flag fails whenever the report is non-empty. In practice you'll want it together with `--changed-files`: when you only report the files you changed, only those files are evaluated, so a fully covered (or empty) changed-file set passes the build even if untouched files elsewhere are poorly covered.
 
 ```sh
 # Post the report to the PR, then redden the build if a changed file is under-covered:

--- a/lib/couve/parser.rb
+++ b/lib/couve/parser.rb
@@ -49,7 +49,7 @@ module Couve
 
     def to_markdown
       rows = @coverage[:source_files].map do |source_file|
-        percentage = source_file[:covered_percent].round(2)
+        percentage = format("%.2f", source_file[:covered_percent].floor(2))
         indicator = percentage_indicator(source_file[:covered_percent])
 
         "| #{indicator} | #{percentage}% | #{source_file[:name]} | #{not_covered_lines(source_file)} |"
@@ -82,7 +82,7 @@ module Couve
       html = ["<tbody>"]
 
       @coverage[:source_files].each do |source_file|
-        percentage = source_file[:covered_percent].round(2)
+        percentage = format("%.2f", source_file[:covered_percent].floor(2))
         bg_color = percentage_bar_color(source_file[:covered_percent])
 
         html << "  <tr>"

--- a/lib/couve/parser.rb
+++ b/lib/couve/parser.rb
@@ -5,7 +5,7 @@ require "json"
 module Couve
   class Parser # rubocop:disable Metrics/ClassLength
     RED_THRESHOLD = 33.33
-    GREEN_THRESHOLD = 66.66
+    GREEN_THRESHOLD = 100
 
     def initialize(coverage, changed_files: nil)
       @coverage = JSON.parse(coverage, symbolize_names: true)
@@ -50,7 +50,7 @@ module Couve
     def to_markdown
       rows = @coverage[:source_files].map do |source_file|
         percentage = source_file[:covered_percent].round(2)
-        indicator = percentage_indicator(percentage)
+        indicator = percentage_indicator(source_file[:covered_percent])
 
         "| #{indicator} | #{percentage}% | #{source_file[:name]} | #{not_covered_lines(source_file)} |"
       end
@@ -66,7 +66,7 @@ module Couve
 
     def low_coverage_files
       @coverage[:source_files]
-        .select { |source_file| source_file[:covered_percent].round(2) < GREEN_THRESHOLD }
+        .select { |source_file| source_file[:covered_percent] < GREEN_THRESHOLD }
         .map { |source_file| source_file[:name] }
     end
 
@@ -83,7 +83,7 @@ module Couve
 
       @coverage[:source_files].each do |source_file|
         percentage = source_file[:covered_percent].round(2)
-        bg_color = percentage_bar_color(percentage)
+        bg_color = percentage_bar_color(source_file[:covered_percent])
 
         html << "  <tr>"
         html << "    <td class=\"col-1\">"

--- a/lib/couve/version.rb
+++ b/lib/couve/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Couve
-  VERSION = "0.8.0"
+  VERSION = "0.9.0"
 end

--- a/spec/fixtures/codeclimate.json
+++ b/spec/fixtures/codeclimate.json
@@ -14,6 +14,11 @@
       "coverage": "[2,2,2,null,null,null,null,null,null,2,2,2,2,null,null,null,2,null,2,2,null,0,null,0,null,null,2,null,null,2,2,null,0,0,null,0,null,null,0,null,2,null,0,null,null,null,2,0,0,null,0,null,null]",
       "covered_percent": 60,
       "name": "app/graphql/resolvers/people_resolver.rb"
+    },
+    {
+      "coverage": "[1,1,null,1]",
+      "covered_percent": 100,
+      "name": "app/models/fully_covered.rb"
     }
   ]
 }

--- a/spec/fixtures/coverage.html
+++ b/spec/fixtures/coverage.html
@@ -34,7 +34,7 @@
             <td class="col-1">
               <div class="progress">
                 <div
-                  class="progress-bar bg-success"
+                  class="progress-bar bg-warning"
                   role="progressbar"
                   style="width: 83.33%;"
                   aria-valuenow="83.33"
@@ -50,7 +50,7 @@
             <td class="col-1">
               <div class="progress">
                 <div
-                  class="progress-bar bg-success"
+                  class="progress-bar bg-warning"
                   role="progressbar"
                   style="width: 93.33%;"
                   aria-valuenow="93.33"

--- a/spec/fixtures/coverage.html
+++ b/spec/fixtures/coverage.html
@@ -20,13 +20,13 @@
                 <div
                   class="progress-bar bg-warning"
                   role="progressbar"
-                  style="width: 60%;"
-                  aria-valuenow="60"
+                  style="width: 60.00%;"
+                  aria-valuenow="60.00"
                   aria-valuemin="0" aria-valuemax="100">
                 </div>
               </div>
             </td>
-            <td class="col-1">60%</td>
+            <td class="col-1">60.00%</td>
             <td class="col-8 text-break">app/graphql/resolvers/people_resolver.rb</td>
             <td class="col-3 text-break">22, 24, 33, 34, 36, 39, 43, 48, 49, 51</td>
           </tr>

--- a/spec/lib/couve/parser_spec.rb
+++ b/spec/lib/couve/parser_spec.rb
@@ -72,13 +72,13 @@ RSpec.describe Couve::Parser do
                       <div
                         class="progress-bar bg-warning"
                         role="progressbar"
-                        style="width: 89%;"
-                        aria-valuenow="89"
+                        style="width: 89.00%;"
+                        aria-valuenow="89.00"
                         aria-valuemin="0" aria-valuemax="100">
                       </div>
                     </div>
                   </td>
-                  <td class="col-1">89%</td>
+                  <td class="col-1">89.00%</td>
                   <td class="col-8 text-break">app/javascript/index.tsx</td>
                   <td class="col-3 text-break"></td>
                 </tr>
@@ -88,13 +88,13 @@ RSpec.describe Couve::Parser do
                       <div
                         class="progress-bar bg-warning"
                         role="progressbar"
-                        style="width: 95%;"
-                        aria-valuenow="95"
+                        style="width: 95.00%;"
+                        aria-valuenow="95.00"
                         aria-valuemin="0" aria-valuemax="100">
                       </div>
                     </div>
                   </td>
-                  <td class="col-1">95%</td>
+                  <td class="col-1">95.00%</td>
                   <td class="col-8 text-break">app/javascript/routes.jsx</td>
                   <td class="col-3 text-break"></td>
                 </tr>
@@ -104,13 +104,13 @@ RSpec.describe Couve::Parser do
                       <div
                         class="progress-bar bg-warning"
                         role="progressbar"
-                        style="width: 99%;"
-                        aria-valuenow="99"
+                        style="width: 99.00%;"
+                        aria-valuenow="99.00"
                         aria-valuemin="0" aria-valuemax="100">
                       </div>
                     </div>
                   </td>
-                  <td class="col-1">99%</td>
+                  <td class="col-1">99.00%</td>
                   <td class="col-8 text-break">app/graphql/resolvers/people_resolver.rb</td>
                   <td class="col-3 text-break"></td>
                 </tr>
@@ -154,8 +154,8 @@ RSpec.describe Couve::Parser do
 
     subject = described_class.new(coverage)
 
-    expect(subject.to_html).to include "95%"
-    expect(subject.to_html).to_not include "100%"
+    expect(subject.to_html).to include "95.00%"
+    expect(subject.to_html).to_not include "100.00%"
   end
 
   it "sorts by less covered first" do
@@ -187,7 +187,7 @@ RSpec.describe Couve::Parser do
     td_elements = doc.css("tbody tr td:nth-child(2)")
     found_percentages = td_elements.map { |td| td.text.strip }
 
-    expect(found_percentages).to eql ["60%", "83.33%", "93.33%"]
+    expect(found_percentages).to eql ["60.00%", "83.33%", "93.33%"]
   end
 
   describe "coverage level colors" do
@@ -267,7 +267,7 @@ RSpec.describe Couve::Parser do
       expect(td_elements.to_s).to include("<div class=\"progress-bar bg-success\"")
     end
 
-    it "colors from the unrounded percentage, even when it rounds up to the threshold" do
+    it "never colors or displays a partially covered file as fully covered" do
       coverage = <<~COVERAGE
         {
           "source_files": [
@@ -283,7 +283,7 @@ RSpec.describe Couve::Parser do
       subject = described_class.new(coverage)
       doc = Nokogiri::HTML(subject.to_html)
 
-      expect(doc.css("tbody tr td:nth-child(2)").text.strip).to eql "100.0%"
+      expect(doc.css("tbody tr td:nth-child(2)").text.strip).to eql "99.99%"
       expect(doc.css("tbody .progress").to_s).to include("<div class=\"progress-bar bg-warning\"")
     end
   end
@@ -361,8 +361,8 @@ RSpec.describe Couve::Parser do
 
         | Rating | Coverage | File | Not covered lines |
         | :---: | ---: | :--- | :--- |
-        | 🔴 | 30% | app/graphql/resolvers/people_resolver.rb | 22, 24, 33, 34, 36, 39, 43, 48, 49, 51 |
-        | 🟡 | 50% | app/javascript/routes.jsx | 24 |
+        | 🔴 | 30.00% | app/graphql/resolvers/people_resolver.rb | 22, 24, 33, 34, 36, 39, 43, 48, 49, 51 |
+        | 🟡 | 50.00% | app/javascript/routes.jsx | 24 |
         | 🟡 | 93.33% | app/javascript/index.tsx | 28 |
       MARKDOWN
 
@@ -391,8 +391,8 @@ RSpec.describe Couve::Parser do
 
       subject = described_class.new(coverage)
 
-      expect(subject.to_markdown).to include "95%"
-      expect(subject.to_markdown).to_not include "100%"
+      expect(subject.to_markdown).to include "95.00%"
+      expect(subject.to_markdown).to_not include "100.00%"
       expect(subject.to_markdown).to_not include "index.tsx"
     end
 
@@ -424,7 +424,7 @@ RSpec.describe Couve::Parser do
       rows = subject.to_markdown.lines.grep(/\| /).reject { |line| line.include?("---") || line.include?("Coverage |") }
       found_percentages = rows.map { |row| row[/\d+(\.\d+)?%/] }
 
-      expect(found_percentages).to eql ["60%", "83.33%", "93.33%"]
+      expect(found_percentages).to eql ["60.00%", "83.33%", "93.33%"]
     end
 
     describe "coverage level indicators" do
@@ -440,7 +440,7 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage)
 
-        expect(subject.to_markdown).to include "| 🔴 | 0% | a |"
+        expect(subject.to_markdown).to include "| 🔴 | 0.00% | a |"
         expect(subject.to_markdown).to include "| 🔴 | 33.32% | b |"
       end
 
@@ -471,10 +471,10 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage, changed_files: ["a"])
 
-        expect(subject.to_markdown).to include "| 🟢 | 100% | a |"
+        expect(subject.to_markdown).to include "| 🟢 | 100.00% | a |"
       end
 
-      it "rates from the unrounded percentage, even when it rounds up to the threshold" do
+      it "never rates or displays a partially covered file as fully covered" do
         coverage = <<~COVERAGE
           {
             "source_files": [
@@ -485,7 +485,7 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage)
 
-        expect(subject.to_markdown).to include "| 🟡 | 100.0% | a |"
+        expect(subject.to_markdown).to include "| 🟡 | 99.99% | a |"
       end
     end
   end
@@ -513,7 +513,7 @@ RSpec.describe Couve::Parser do
     it "includes a fully covered file when it is in the list" do
       subject = described_class.new(coverage, changed_files: ["app/models/fully_covered.rb"])
 
-      expect(subject.to_markdown).to include "| 🟢 | 100% | app/models/fully_covered.rb |"
+      expect(subject.to_markdown).to include "| 🟢 | 100.00% | app/models/fully_covered.rb |"
     end
 
     it "excludes a file below 100% that is not in the list" do
@@ -544,7 +544,7 @@ RSpec.describe Couve::Parser do
       rows = subject.to_markdown.lines.grep(/\| /).reject { |line| line.include?("---") || line.include?("Coverage |") }
       found_percentages = rows.map { |row| row[/\d+(\.\d+)?%/] }
 
-      expect(found_percentages).to eql ["50%", "100%"]
+      expect(found_percentages).to eql ["50.00%", "100.00%"]
     end
   end
 

--- a/spec/lib/couve/parser_spec.rb
+++ b/spec/lib/couve/parser_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Couve::Parser do
                   <td class="col-1">
                     <div class="progress">
                       <div
-                        class="progress-bar bg-success"
+                        class="progress-bar bg-warning"
                         role="progressbar"
                         style="width: 89%;"
                         aria-valuenow="89"
@@ -86,7 +86,7 @@ RSpec.describe Couve::Parser do
                   <td class="col-1">
                     <div class="progress">
                       <div
-                        class="progress-bar bg-success"
+                        class="progress-bar bg-warning"
                         role="progressbar"
                         style="width: 95%;"
                         aria-valuenow="95"
@@ -102,7 +102,7 @@ RSpec.describe Couve::Parser do
                   <td class="col-1">
                     <div class="progress">
                       <div
-                        class="progress-bar bg-success"
+                        class="progress-bar bg-warning"
                         role="progressbar"
                         style="width: 99%;"
                         aria-valuenow="99"
@@ -219,7 +219,7 @@ RSpec.describe Couve::Parser do
       expect(td_elements.to_s).to include("<div class=\"progress-bar bg-danger\"")
     end
 
-    it "is yellow when coverage is between 33.34% and 66.65%" do
+    it "is yellow when coverage is between 33.34% and 99.99%" do
       coverage = <<~COVERAGE
         {
           "source_files": [
@@ -230,7 +230,7 @@ RSpec.describe Couve::Parser do
             },
             {
               "coverage": "[]",
-              "covered_percent": 66.65,
+              "covered_percent": 99.99,
               "name": ""
             }
           ]
@@ -247,18 +247,33 @@ RSpec.describe Couve::Parser do
       expect(td_elements.to_s).to include("<div class=\"progress-bar bg-warning\"")
     end
 
-    it "is green when coverage is greater than 66.65%" do
+    it "is green only when the file is fully covered" do
       coverage = <<~COVERAGE
         {
           "source_files": [
             {
               "coverage": "[]",
-              "covered_percent": 66.66,
-              "name": ""
-            },
+              "covered_percent": 100,
+              "name": "app/full.rb"
+            }
+          ]
+        }
+      COVERAGE
+
+      subject = described_class.new(coverage, changed_files: ["app/full.rb"])
+      doc = Nokogiri::HTML(subject.to_html)
+
+      td_elements = doc.css("tbody tr:nth-child(1) td:nth-child(1) .progress")
+      expect(td_elements.to_s).to include("<div class=\"progress-bar bg-success\"")
+    end
+
+    it "colors from the unrounded percentage, even when it rounds up to the threshold" do
+      coverage = <<~COVERAGE
+        {
+          "source_files": [
             {
               "coverage": "[]",
-              "covered_percent": 99.99,
+              "covered_percent": 99.996,
               "name": ""
             }
           ]
@@ -268,11 +283,8 @@ RSpec.describe Couve::Parser do
       subject = described_class.new(coverage)
       doc = Nokogiri::HTML(subject.to_html)
 
-      td_elements = doc.css("tbody tr:nth-child(1) td:nth-child(1) .progress")
-      expect(td_elements.to_s).to include("<div class=\"progress-bar bg-success\"")
-
-      td_elements = doc.css("tbody tr:nth-child(2) td:nth-child(1) .progress")
-      expect(td_elements.to_s).to include("<div class=\"progress-bar bg-success\"")
+      expect(doc.css("tbody tr td:nth-child(2)").text.strip).to eql "100.0%"
+      expect(doc.css("tbody .progress").to_s).to include("<div class=\"progress-bar bg-warning\"")
     end
   end
 
@@ -351,7 +363,7 @@ RSpec.describe Couve::Parser do
         | :---: | ---: | :--- | :--- |
         | 🔴 | 30% | app/graphql/resolvers/people_resolver.rb | 22, 24, 33, 34, 36, 39, 43, 48, 49, 51 |
         | 🟡 | 50% | app/javascript/routes.jsx | 24 |
-        | 🟢 | 93.33% | app/javascript/index.tsx | 28 |
+        | 🟡 | 93.33% | app/javascript/index.tsx | 28 |
       MARKDOWN
 
       subject = described_class.new(coverage)
@@ -432,27 +444,11 @@ RSpec.describe Couve::Parser do
         expect(subject.to_markdown).to include "| 🔴 | 33.32% | b |"
       end
 
-      it "is yellow when coverage is between 33.34% and 66.65%" do
+      it "is yellow when coverage is between 33.34% and 99.99%" do
         coverage = <<~COVERAGE
           {
             "source_files": [
               { "coverage": "[]", "covered_percent": 33.34, "name": "a" },
-              { "coverage": "[]", "covered_percent": 66.65, "name": "b" }
-            ]
-          }
-        COVERAGE
-
-        subject = described_class.new(coverage)
-
-        expect(subject.to_markdown).to include "| 🟡 | 33.34% | a |"
-        expect(subject.to_markdown).to include "| 🟡 | 66.65% | b |"
-      end
-
-      it "is green when coverage is greater than 66.65%" do
-        coverage = <<~COVERAGE
-          {
-            "source_files": [
-              { "coverage": "[]", "covered_percent": 66.66, "name": "a" },
               { "coverage": "[]", "covered_percent": 99.99, "name": "b" }
             ]
           }
@@ -460,8 +456,36 @@ RSpec.describe Couve::Parser do
 
         subject = described_class.new(coverage)
 
-        expect(subject.to_markdown).to include "| 🟢 | 66.66% | a |"
-        expect(subject.to_markdown).to include "| 🟢 | 99.99% | b |"
+        expect(subject.to_markdown).to include "| 🟡 | 33.34% | a |"
+        expect(subject.to_markdown).to include "| 🟡 | 99.99% | b |"
+      end
+
+      it "is green only when the file is fully covered" do
+        coverage = <<~COVERAGE
+          {
+            "source_files": [
+              { "coverage": "[]", "covered_percent": 100, "name": "a" }
+            ]
+          }
+        COVERAGE
+
+        subject = described_class.new(coverage, changed_files: ["a"])
+
+        expect(subject.to_markdown).to include "| 🟢 | 100% | a |"
+      end
+
+      it "rates from the unrounded percentage, even when it rounds up to the threshold" do
+        coverage = <<~COVERAGE
+          {
+            "source_files": [
+              { "coverage": "[]", "covered_percent": 99.996, "name": "a" }
+            ]
+          }
+        COVERAGE
+
+        subject = described_class.new(coverage)
+
+        expect(subject.to_markdown).to include "| 🟡 | 100.0% | a |"
       end
     end
   end
@@ -525,49 +549,51 @@ RSpec.describe Couve::Parser do
   end
 
   describe "#low_coverage_files" do
-    it "returns only the files below the green threshold" do
+    it "returns every reported file that is not fully covered" do
       coverage = <<~COVERAGE
         {
           "source_files": [
             { "coverage": "[]", "covered_percent": 30, "name": "app/red.rb" },
             { "coverage": "[]", "covered_percent": 50, "name": "app/yellow.rb" },
-            { "coverage": "[]", "covered_percent": 80, "name": "app/green.rb" }
+            { "coverage": "[]", "covered_percent": 80, "name": "app/high.rb" },
+            { "coverage": "[]", "covered_percent": 100, "name": "app/full.rb" }
           ]
         }
       COVERAGE
 
-      subject = described_class.new(coverage)
+      changed_files = ["app/red.rb", "app/yellow.rb", "app/high.rb", "app/full.rb"]
+      subject = described_class.new(coverage, changed_files: changed_files)
 
-      expect(subject.low_coverage_files).to eql ["app/red.rb", "app/yellow.rb"]
+      expect(subject.low_coverage_files).to eql ["app/red.rb", "app/yellow.rb", "app/high.rb"]
     end
 
-    it "treats 66.66% as green and 66.65% as low, matching the report indicators" do
+    it "treats 100% as green and 99.99% as low, matching the report indicators" do
       coverage = <<~COVERAGE
         {
           "source_files": [
-            { "coverage": "[]", "covered_percent": 66.65, "name": "app/low.rb" },
-            { "coverage": "[]", "covered_percent": 66.66, "name": "app/ok.rb" }
+            { "coverage": "[]", "covered_percent": 99.99, "name": "app/low.rb" },
+            { "coverage": "[]", "covered_percent": 100, "name": "app/ok.rb" }
           ]
         }
       COVERAGE
 
-      subject = described_class.new(coverage)
+      subject = described_class.new(coverage, changed_files: ["app/low.rb", "app/ok.rb"])
 
       expect(subject.low_coverage_files).to eql ["app/low.rb"]
     end
 
-    it "rounds to two decimals like the report, so 66.659% counts as green" do
+    it "compares the unrounded percentage, so a file that rounds up to the threshold is still low" do
       coverage = <<~COVERAGE
         {
           "source_files": [
-            { "coverage": "[]", "covered_percent": 66.659, "name": "app/rounds_up.rb" }
+            { "coverage": "[]", "covered_percent": 99.996, "name": "app/rounds_up.rb" }
           ]
         }
       COVERAGE
 
       subject = described_class.new(coverage)
 
-      expect(subject.low_coverage_files).to be_empty
+      expect(subject.low_coverage_files).to eql ["app/rounds_up.rb"]
     end
 
     it "is scoped to the changed files when given" do
@@ -575,7 +601,7 @@ RSpec.describe Couve::Parser do
         {
           "source_files": [
             { "coverage": "[]", "covered_percent": 30, "name": "app/untouched_red.rb" },
-            { "coverage": "[]", "covered_percent": 95, "name": "app/touched_green.rb" }
+            { "coverage": "[]", "covered_percent": 100, "name": "app/touched_green.rb" }
           ]
         }
       COVERAGE
@@ -599,16 +625,18 @@ RSpec.describe Couve::Parser do
       expect(described_class.new(coverage).low_coverage?).to be true
     end
 
-    it "is false when every reported file is green" do
+    it "is false when every reported file is fully covered" do
       coverage = <<~COVERAGE
         {
           "source_files": [
-            { "coverage": "[]", "covered_percent": 80, "name": "app/green.rb" }
+            { "coverage": "[]", "covered_percent": 100, "name": "app/full.rb" }
           ]
         }
       COVERAGE
 
-      expect(described_class.new(coverage).low_coverage?).to be false
+      subject = described_class.new(coverage, changed_files: ["app/full.rb"])
+
+      expect(subject.low_coverage?).to be false
     end
   end
 end

--- a/spec/lib/couve_spec.rb
+++ b/spec/lib/couve_spec.rb
@@ -100,14 +100,14 @@ RSpec.describe Couve do
           subject.start(["spec/fixtures/codeclimate.json", output_file, "--fail-on-low-coverage"])
         rescue SystemExit
           # expected
-        end.to output(/couve: coverage below 66.66% in .*people_resolver\.rb/).to_stderr
+        end.to output(/couve: coverage below 100% in .*people_resolver\.rb/).to_stderr
       end
 
       it "does not exit when every reported file is green" do
         output_file = "tmp/pass.md"
         list_file = "tmp/pass.txt"
         FileUtils.rm_f(output_file)
-        File.write(list_file, "app/javascript/routes.jsx\n")
+        File.write(list_file, "app/models/fully_covered.rb\n")
 
         expect do
           subject.start(["spec/fixtures/codeclimate.json", output_file, "--changed-files", list_file,


### PR DESCRIPTION
Closes #13

## Summary
**Why:** a file at 66.66% coverage rated 🟢 and passed the `--fail-on-low-coverage` gate, which made the green rating misleading — a file could be marked green with a third of it untested.

- Raise `Parser::GREEN_THRESHOLD` from `66.66` to `100`: 🟢 (and `bg-success` in the HTML report) now means the file is fully covered, and `--fail-on-low-coverage` exits `1` for any reported file below 100%. `RED_THRESHOLD` is unchanged, so 🟡 now spans 33.34%–99.99%.
- Compare the **unrounded** `covered_percent` in `low_coverage_files`, `percentage_indicator`, and `percentage_bar_color`, so a file at e.g. 99.996% no longer rounds up to 100% and slips past the gate.
- Display percentages with two decimal places in all cases (e.g. `60.00%`), **flooring** instead of rounding, so a partially covered file never displays as `100.00%` — a 99.996% file shows `99.99%`, rates 🟡, and fails the build.
- Update README (rating bands, gate docs, report example), add a 0.9.0 CHANGELOG entry flagging the breaking change, and bump the version to 0.9.0.
- No change needed in `lib/couve.rb`: the stderr message and `--help` text interpolate the constant and now read "below 100%".

## How to test
- [ ] `bundle exec rspec` — 37 examples, 0 failures (developed with strict TDD: every behavior change landed as a failing spec first).
- [ ] `bundle exec rubocop` — no offenses.
- [ ] `bundle exec exe/couve spec/fixtures/codeclimate.json tmp/report.md --fail-on-low-coverage` — exits `1`, prints `couve: coverage below 100% in ...`, and the report rates the 60.00%/83.33%/93.33% files 🟡.

## Notes
Behavioral consequence worth knowing: the default (project-wide) report already hides fully covered files, so with this change every reported file is 🔴/🟡 and `--fail-on-low-coverage` fails whenever the report is non-empty. In practice the flag pairs with `--changed-files`, where a fully covered changed-file set still passes; this is now documented in the README. Released as 0.9.0 since it changes the gate behavior for existing users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
